### PR TITLE
Fix Message-ID extraction for 2-part MIME bounces and add References/…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
 	"name": "zoonru/php-bounce-handler",
-	"version": "8.0.0",
 	"require": {
 		"php": ">=8.4"
 	},

--- a/eml/fixture_bounce_009.eml
+++ b/eml/fixture_bounce_009.eml
@@ -1,0 +1,56 @@
+Delivered-To: postmaster@example.test
+Return-Path: <postmaster@mailer2.example.test>
+X-Failed-Recipients: recipient.three@example.test
+Auto-Submitted: auto-replied
+From: Mail Delivery System <Mailer-Daemon@mailer2.example.test>
+To: postmaster@example.test
+References: <ref-message-001@example.test>
+Content-Type: multipart/report; report-type=delivery-status; boundary=BOUNDARY-BOUNCE-009
+MIME-Version: 1.0
+Subject: Mail delivery failed
+Message-Id: <bounce-message-001@example.test>
+Date: Wed, 11 Feb 2026 11:18:40 +0300
+
+--BOUNDARY-BOUNCE-009
+Content-type: text/plain; charset=us-ascii
+
+This message was created automatically by mail delivery software.
+
+A message sent by
+
+  <sender@example.test>
+
+could not be delivered to one or more of its recipients. The following
+address(es) failed:
+
+  recipient.three@example.test
+    host mx.remote-3.example.net [198.51.100.30]
+    SMTP error from remote mail server after RCPT TO:<recipient.three@example.test>:
+    550 zen.example.test Listed by CSS
+
+--BOUNDARY-BOUNCE-009
+Content-type: message/delivery-status
+
+Reporting-MTA: dns; mailer2.example.test
+
+Action: failed
+Final-Recipient: rfc822;recipient.three@example.test
+Status: 5.0.0
+Remote-MTA: dns; mx.remote-3.example.net
+Diagnostic-Code: smtp; 550 zen.example.test Listed by CSS
+
+--BOUNDARY-BOUNCE-009
+Content-type: message/rfc822
+
+Return-path: <sender@example.test>
+From: Sender Team <sender@example.test>
+Message-ID: <original-message-001@example.test>
+Subject: Monthly report: Sample Org
+To: recipient.three@example.test
+MIME-Version: 1.0
+Date: Wed, 11 Feb 2026 11:18:37 +0300
+Content-Type: text/plain; charset=utf-8
+
+Original message body.
+
+--BOUNDARY-BOUNCE-009--

--- a/tests/HeaderParserTest.php
+++ b/tests/HeaderParserTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zoon\BounceHandler\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Zoon\BounceHandler\Parser\HeaderParser;
+
+final class HeaderParserTest extends TestCase {
+	public function testParseKeyValueDoesNotEmitWarningsOnInvalidMimeEncodedHeader(): void {
+		$headers = [
+			'Subject: =?UTF-8?Q?Broken_=ZZ?=',
+			' =?UTF-8?Q?continuation_=XX?=',
+		];
+
+		set_error_handler(static function (int $severity, string $message): bool {
+			throw new \ErrorException($message, 0, $severity);
+		});
+
+		try {
+			$parsed = HeaderParser::parseKeyValue($headers);
+		} finally {
+			restore_error_handler();
+		}
+
+		self::assertArrayHasKey('Subject', $parsed);
+		self::assertIsString($parsed['Subject']);
+		self::assertNotSame('', $parsed['Subject']);
+	}
+}

--- a/tests/MessageIdExtractionTest.php
+++ b/tests/MessageIdExtractionTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zoon\BounceHandler\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Zoon\BounceHandler\BounceHandler;
+
+final class MessageIdExtractionTest extends TestCase {
+	private BounceHandler $handler;
+
+	protected function setUp(): void {
+		$this->handler = new BounceHandler();
+	}
+
+	public function testMessageIdFromStandard3PartMime(): void {
+		$eml = $this->buildEml([
+			'Return-Path' => '<>',
+			'From' => 'mailer-daemon@example.com',
+			'Subject' => 'Mail delivery failed',
+			'Content-Type' => 'multipart/report; report-type=delivery-status; boundary="BOUND3PART"',
+		], implode("\r\n", [
+			'--BOUND3PART',
+			'Content-Type: text/plain',
+			'',
+			'The message could not be delivered.',
+			'user@example.com: mailbox not found',
+			'',
+			'--BOUND3PART',
+			'Content-Type: message/delivery-status',
+			'',
+			'Final-Recipient: rfc822;user@example.com',
+			'Action: failed',
+			'Status: 5.1.1',
+			'',
+			'--BOUND3PART',
+			'Content-Type: message/rfc822',
+			'',
+			'Message-ID: <original-3part@example.com>',
+			'From: sender@example.com',
+			'To: user@example.com',
+			'Subject: Original Subject',
+			'',
+			'Original body text',
+			'--BOUND3PART--',
+		]));
+
+		$results = $this->handler->parse($eml);
+
+		self::assertCount(1, $results);
+		self::assertSame('<original-3part@example.com>', $results[0]->messageId);
+		self::assertSame('Original Subject', $results[0]->subject);
+	}
+
+	public function testMessageIdFrom2PartMimeFallback(): void {
+		$eml = $this->buildEml([
+			'Return-Path' => '<>',
+			'From' => 'mailer-daemon@example.com',
+			'Subject' => 'Mail delivery failed',
+			'Content-Type' => 'multipart/mixed; boundary="BOUND2PART"',
+		], implode("\r\n", [
+			'--BOUND2PART',
+			'',
+			'Su mensaje no pudo ser entregado.',
+			'user@example.com: mailbox not found',
+			'',
+			'--- Mensaje original adjunto.',
+			'',
+			'--BOUND2PART',
+			'Content-Type: message/rfc822',
+			'',
+			'Message-ID: <original-2part@example.com>',
+			'From: sender@example.com',
+			'To: user@example.com',
+			'Subject: Two Part Subject',
+			'',
+			'Original body text',
+			'--BOUND2PART--',
+		]));
+
+		$results = $this->handler->parse($eml);
+
+		self::assertCount(1, $results);
+		self::assertSame('<original-2part@example.com>', $results[0]->messageId);
+		self::assertSame('Two Part Subject', $results[0]->subject);
+	}
+
+	public function testMessageIdFromReferencesHeader(): void {
+		$eml = $this->buildEml([
+			'Return-Path' => '<>',
+			'From' => 'mailer-daemon@example.com',
+			'Subject' => 'Mail delivery failed',
+			'References' => '<ref-fallback@example.com>',
+			'X-Failed-Recipients' => 'user@example.com',
+		], implode("\r\n", [
+			'This message was created automatically by mail delivery software.',
+			'',
+			'A message that you sent could not be delivered.',
+			'',
+			'  user@example.com',
+			'    mailbox is full',
+		]));
+
+		$results = $this->handler->parse($eml);
+
+		self::assertCount(1, $results);
+		self::assertSame('<ref-fallback@example.com>', $results[0]->messageId);
+	}
+
+	public function testMessageIdFromInReplyToHeader(): void {
+		$eml = $this->buildEml([
+			'Return-Path' => '<>',
+			'From' => 'mailer-daemon@example.com',
+			'Subject' => 'Mail delivery failed',
+			'In-Reply-To' => '<inreply-fallback@example.com>',
+			'X-Failed-Recipients' => 'user@example.com',
+		], implode("\r\n", [
+			'This message was created automatically by mail delivery software.',
+			'',
+			'A message that you sent could not be delivered.',
+			'',
+			'  user@example.com',
+			'    mailbox is full',
+		]));
+
+		$results = $this->handler->parse($eml);
+
+		self::assertCount(1, $results);
+		self::assertSame('<inreply-fallback@example.com>', $results[0]->messageId);
+	}
+
+	public function testReferencesPreferredOverInReplyTo(): void {
+		$eml = $this->buildEml([
+			'Return-Path' => '<>',
+			'From' => 'mailer-daemon@example.com',
+			'Subject' => 'Mail delivery failed',
+			'References' => '<from-references@example.com>',
+			'In-Reply-To' => '<from-inreply@example.com>',
+			'X-Failed-Recipients' => 'user@example.com',
+		], implode("\r\n", [
+			'This message was created automatically by mail delivery software.',
+			'',
+			'  user@example.com',
+			'    mailbox is full',
+		]));
+
+		$results = $this->handler->parse($eml);
+
+		self::assertCount(1, $results);
+		self::assertSame('<from-references@example.com>', $results[0]->messageId);
+	}
+
+	public function testOriginalLetterMessageIdPreferredOverReferences(): void {
+		$eml = $this->buildEml([
+			'Return-Path' => '<>',
+			'From' => 'mailer-daemon@example.com',
+			'Subject' => 'Mail delivery failed',
+			'References' => '<should-not-use@example.com>',
+			'Content-Type' => 'multipart/report; report-type=delivery-status; boundary="BOUNDPRIO"',
+		], implode("\r\n", [
+			'--BOUNDPRIO',
+			'Content-Type: text/plain',
+			'',
+			'user@example.com: mailbox not found',
+			'',
+			'--BOUNDPRIO',
+			'Content-Type: message/delivery-status',
+			'',
+			'Final-Recipient: rfc822;user@example.com',
+			'Action: failed',
+			'Status: 5.1.1',
+			'',
+			'--BOUNDPRIO',
+			'Content-Type: message/rfc822',
+			'',
+			'Message-ID: <from-original@example.com>',
+			'From: sender@example.com',
+			'To: user@example.com',
+			'Subject: Test',
+			'',
+			'Body',
+			'--BOUNDPRIO--',
+		]));
+
+		$results = $this->handler->parse($eml);
+
+		self::assertCount(1, $results);
+		self::assertSame('<from-original@example.com>', $results[0]->messageId);
+	}
+
+	public function testEmptyMessageIdWhenNoSourceAvailable(): void {
+		$eml = $this->buildEml([
+			'Return-Path' => '<>',
+			'From' => 'mailer-daemon@example.com',
+			'Subject' => 'Mail delivery failed',
+			'X-Failed-Recipients' => 'user@example.com',
+		], implode("\r\n", [
+			'This message was created automatically by mail delivery software.',
+			'',
+			'A message that you sent could not be delivered.',
+			'',
+			'  user@example.com',
+			'    mailbox is full',
+		]));
+
+		$results = $this->handler->parse($eml);
+
+		self::assertCount(1, $results);
+		self::assertSame('', $results[0]->messageId);
+	}
+
+	public function testReferencesWithMultipleMessageIds(): void {
+		$eml = $this->buildEml([
+			'Return-Path' => '<>',
+			'From' => 'mailer-daemon@example.com',
+			'Subject' => 'Mail delivery failed',
+			'References' => '<first@example.com> <second@example.com>',
+			'X-Failed-Recipients' => 'user@example.com',
+		], implode("\r\n", [
+			'This message was created automatically by mail delivery software.',
+			'',
+			'  user@example.com',
+			'    mailbox is full',
+		]));
+
+		$results = $this->handler->parse($eml);
+
+		self::assertCount(1, $results);
+		self::assertSame('<first@example.com>', $results[0]->messageId);
+	}
+
+	public function testRealEmlFile1HasMessageId(): void {
+		$emlPath = __DIR__ . '/../eml/1.eml';
+		if (!file_exists($emlPath)) {
+			self::markTestSkipped('eml/1.eml not found');
+		}
+
+		$results = $this->handler->parse(file_get_contents($emlPath));
+
+		self::assertGreaterThan(0, count($results));
+		self::assertSame(
+			'<11885fd3ea338f04de950704ee6b30f5@ar1.outmailing.com>',
+			$results[0]->messageId,
+		);
+	}
+
+	/**
+	 * @param array<string, string> $headers
+	 */
+	private function buildEml(array $headers, string $body): string {
+		$lines = [];
+		foreach ($headers as $name => $value) {
+			$lines[] = "{$name}: {$value}";
+		}
+
+		return implode("\r\n", $lines) . "\r\n\r\n" . $body;
+	}
+}


### PR DESCRIPTION
…In-Reply-To fallback

- recoverOriginalLetter: don't return early when returnedMessageBodyPart yields empty result, fall through to next strategies
- recoverOriginalLetter: add fallback to machineParsableBodyPart when it contains message/rfc822 (handles 2-part MIME bounces)
- parse: fall back to References and In-Reply-To headers when original letter Message-ID is unavailable
- Add MessageIdExtractionTest covering all extraction paths