### PR TITLE
perf(BounceDetector): предфильтр вместо перебора ~197 паттернов на строку

### DIFF
--- a/src/Data/BouncePatterns.php
+++ b/src/Data/BouncePatterns.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Zoon\BounceHandler\Data;
 
 final class BouncePatterns {
+	/** @var non-empty-string|null */
+	private static ?string $combinedBounceRegex = null;
+
 	/**
 	 * Regex-to-status-code mapping for bounce detection.
 	 * Value 'x' means extract the code from regex capture group 1.
@@ -285,4 +288,20 @@ final class BouncePatterns {
 		// "Ваше сообщение не доставлено" in UTF-8 hex
 		'Ваше сообщение не доставлено',
 	];
+
+	/**
+	 * Single alternation built from every BOUNCE_LIST pattern.
+	 *
+	 * A line that does not match it cannot match any individual pattern either, so it lets
+	 * callers skip the ~200-iteration scan over BOUNCE_LIST entirely. Built once per process.
+	 *
+	 * @return non-empty-string
+	 */
+	public static function getCombinedBounceRegex(): string {
+		if (self::$combinedBounceRegex === null) {
+			self::$combinedBounceRegex = '/(?:' . implode(')|(?:', array_keys(self::BOUNCE_LIST)) . ')/i';
+		}
+
+		return self::$combinedBounceRegex;
+	}
 }

--- a/src/Data/BouncePatterns.php
+++ b/src/Data/BouncePatterns.php
@@ -295,6 +295,10 @@ final class BouncePatterns {
 	 * A line that does not match it cannot match any individual pattern either, so it lets
 	 * callers skip the ~200-iteration scan over BOUNCE_LIST entirely. Built once per process.
 	 *
+	 * The delimiter and flags must stay identical to the ones the scan itself uses in
+	 * BounceDetector::matchBouncePattern(); widening one side only (say to /ui for a Cyrillic
+	 * pattern) turns this into a filter that rejects lines the scan would have matched.
+	 *
 	 * @return non-empty-string
 	 */
 	public static function getCombinedBounceRegex(): string {

--- a/src/Detector/BounceDetector.php
+++ b/src/Detector/BounceDetector.php
@@ -34,13 +34,36 @@ final class BounceDetector {
 	}
 
 	/**
+	 * Longest line, in bytes, that the combined prefilter is worth running on.
+	 *
+	 * The two strategies have opposite cost shapes. The per-pattern scan pays ~200 preg_match
+	 * calls per line, but each is a literal search PCRE can start with a memchr, so it costs
+	 * almost nothing per byte. The combined alternation is a single call, but its start-code-unit
+	 * bitmap covers most letters, so nearly every offset retries ~200 branches and the cost grows
+	 * with the length of the line. Measured on PHP 8.4 / PCRE 10.42 the two meet near 350 bytes,
+	 * and past that the prefilter loses without bound: on one unwrapped 110 KB HTML line the scan
+	 * takes 0.9 ms and the prefilter 6.0 ms.
+	 *
+	 * Real message bodies sit far below the crossover - over the 37868 lines of the eml/ corpus
+	 * p99 is 104 bytes and the longest line is 972 - so the prefilter still covers nearly every
+	 * line, while unwrapped 8bit HTML in a returned original message no longer regresses.
+	 */
+	private const int PREFILTER_MAX_LINE_LENGTH = 256;
+
+	private static ?bool $prefilterUsable = null;
+
+	/**
 	 * Returns the status code of the first BOUNCE_LIST pattern matching the line, or null when none does.
 	 */
 	public static function matchBouncePattern(string $line): ?string {
 		// Cheap prefilter: one combined pattern instead of ~200 preg_match calls per line.
 		// Exactly 0 means no alternation branch matched, so the detailed scan cannot match either.
 		// On a PCRE error (false) we deliberately fall through to the scan rather than lose a match.
-		if (preg_match(BouncePatterns::getCombinedBounceRegex(), $line) === 0) {
+		if (
+			strlen($line) <= self::PREFILTER_MAX_LINE_LENGTH
+			&& self::isPrefilterUsable()
+			&& preg_match(BouncePatterns::getCombinedBounceRegex(), $line) === 0
+		) {
 			return null;
 		}
 
@@ -55,6 +78,19 @@ final class BounceDetector {
 		}
 
 		return null;
+	}
+
+	/**
+	 * The prefilter only pays off while PCRE can JIT-compile it. Interpreted, the combined
+	 * alternation is several times slower than the per-pattern scan at any line length, so on a
+	 * build without JIT support - or with pcre.jit turned off - the scan is used unconditionally.
+	 */
+	private static function isPrefilterUsable(): bool {
+		if (self::$prefilterUsable === null) {
+			self::$prefilterUsable = PCRE_JIT_SUPPORT === true && ini_get('pcre.jit') !== '0';
+		}
+
+		return self::$prefilterUsable;
 	}
 
 	/**

--- a/src/Detector/BounceDetector.php
+++ b/src/Detector/BounceDetector.php
@@ -34,6 +34,30 @@ final class BounceDetector {
 	}
 
 	/**
+	 * Returns the status code of the first BOUNCE_LIST pattern matching the line, or null when none does.
+	 */
+	public static function matchBouncePattern(string $line): ?string {
+		// Cheap prefilter: one combined pattern instead of ~200 preg_match calls per line.
+		// Exactly 0 means no alternation branch matched, so the detailed scan cannot match either.
+		// On a PCRE error (false) we deliberately fall through to the scan rather than lose a match.
+		if (preg_match(BouncePatterns::getCombinedBounceRegex(), $line) === 0) {
+			return null;
+		}
+
+		foreach (BouncePatterns::BOUNCE_LIST as $bouncetext => $bouncecode) {
+			if (preg_match("/{$bouncetext}/i", $line, $matches) === 1) {
+				if (array_key_exists(1, $matches) && $bouncecode === 'x') {
+					return $matches[1];
+				}
+
+				return $bouncecode;
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * @param list<string> $bodyHash
 	 */
 	public static function getStatusCodeFromText(string $recipient, int $startIndex, array $bodyHash): string {
@@ -64,14 +88,9 @@ final class BounceDetector {
 				continue;
 			}
 
-			foreach (BouncePatterns::BOUNCE_LIST as $bouncetext => $bouncecode) {
-				if (preg_match("/{$bouncetext}/i", $line, $matches) === 1) {
-					if (array_key_exists(1, $matches) && $bouncecode === 'x') {
-						return $matches[1];
-					}
-
-					return $bouncecode;
-				}
+			$bounceCode = self::matchBouncePattern($line);
+			if ($bounceCode !== null) {
+				return $bounceCode;
 			}
 
 			if (preg_match('/\W([245]\.[01234567]\.\d{1,2})\W/', $line, $matches) === 1) {

--- a/tests/BounceDetectorTest.php
+++ b/tests/BounceDetectorTest.php
@@ -6,6 +6,7 @@ namespace Zoon\BounceHandler\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use Zoon\BounceHandler\Data\BouncePatterns;
 use Zoon\BounceHandler\Detector\BounceDetector;
 
@@ -47,7 +48,6 @@ final class BounceDetectorTest extends TestCase {
 	public static function bouncePatternProvider(): iterable {
 		foreach (array_keys(BouncePatterns::BOUNCE_LIST) as $pattern) {
 			$sample = self::PATTERN_SAMPLES[$pattern] ?? str_replace(['\.', '\/', '\ '], ['.', '/', ' '], $pattern);
-			self::assertNotSame('', $sample);
 
 			yield $pattern => [$pattern, $sample];
 		}
@@ -55,10 +55,89 @@ final class BounceDetectorTest extends TestCase {
 
 	#[DataProvider('bouncePatternProvider')]
 	public function testPatternSampleIsMatchedTheSameWayAsNaiveScan(string $pattern, string $sample): void {
+		// Без этой проверки образец мог бы совпадать с более ранней записью BOUNCE_LIST,
+		// а собственная ветка паттерна не исполнялась бы ни разу.
+		self::assertSame(1, preg_match("/{$pattern}/i", $sample), "Образец не совпадает со своим паттерном `{$pattern}`");
+
 		$expected = self::naiveMatch($sample);
 
 		self::assertNotNull($expected, "Образец строки для паттерна `{$pattern}` не распознаётся эталонным перебором");
 		self::assertSame($expected, BounceDetector::matchBouncePattern($sample));
+	}
+
+	/**
+	 * Приоритет задаётся порядком записей в BOUNCE_LIST, а не позицией совпадения в строке.
+	 *
+	 * Замена перебора на одну альтернативу с определением ветки прошла бы весь остальной
+	 * набор тестов и молча сменила бы классификацию именно на таких строках.
+	 *
+	 * @return list<array{string, string, string}>
+	 */
+	public static function listOrderProvider(): array {
+		return [
+			['The mailbox is full. Status: 5.2.2', '5.2.2', 'mailbox is full'],
+			['Access denied: no such user', '5.1.1', 'Access denied'],
+		];
+	}
+
+	#[DataProvider('listOrderProvider')]
+	public function testEarlierListEntryWinsOverLeftmostMatch(string $line, string $expected, string $leftmost): void {
+		self::assertSame($expected, BounceDetector::matchBouncePattern($line));
+
+		preg_match(BouncePatterns::getCombinedBounceRegex(), $line, $m);
+		self::assertSame($leftmost, $m[0], 'Строка перестала различать порядок списка и leftmost-совпадение');
+	}
+
+	/**
+	 * Предфильтр корректен только пока ни один паттерн не зависит от нумерации групп.
+	 *
+	 * В объединённой альтернативе номера групп сквозные, поэтому `\1` в поздней ветке
+	 * сошлётся на группу чужой ветки и совпадение будет молча потеряно; две одноимённые
+	 * группы вообще не дадут шаблону скомпилироваться.
+	 */
+	public function testNoBounceListPatternBreaksTheCombinedRegex(): void {
+		$offenders = [];
+		foreach (array_keys(BouncePatterns::BOUNCE_LIST) as $pattern) {
+			if (preg_match('/\\\\[1-9]/', $pattern) === 1) {
+				$offenders[$pattern] = 'обратная ссылка';
+			}
+			if (preg_match('/\(\?P?[<\']/', $pattern) === 1) {
+				$offenders[$pattern] = 'именованная группа';
+			}
+		}
+
+		self::assertSame([], $offenders);
+		self::assertSame(0, preg_match(BouncePatterns::getCombinedBounceRegex(), ''));
+		self::assertSame(PREG_NO_ERROR, preg_last_error(), preg_last_error_msg());
+	}
+
+	/**
+	 * Гейт по JIT легко сделать всегда-ложным (например, сравнив bool-константу с int) — и тогда
+	 * предфильтр молча выключится целиком, не изменив ни одного результата. Поведенческие тесты
+	 * такого не видят, поэтому проверяем решение напрямую.
+	 */
+	public function testPrefilterIsActuallyEnabledWhenJitIsAvailable(): void {
+		if (PCRE_JIT_SUPPORT !== true || ini_get('pcre.jit') === '0') {
+			self::markTestSkipped('PCRE JIT недоступен — предфильтр отключён намеренно');
+		}
+
+		$isUsable = new ReflectionMethod(BounceDetector::class, 'isPrefilterUsable');
+
+		self::assertTrue($isUsable->invoke(null), 'Предфильтр выключен, хотя JIT доступен');
+	}
+
+	/**
+	 * Строки длиннее PREFILTER_MAX_LINE_LENGTH идут мимо предфильтра — прямым перебором.
+	 */
+	public function testLongLineIsMatchedTheSameWayAsNaiveScan(): void {
+		$filler = str_repeat('<td class="wrapper-cell"><span>Lorem ipsum dolor sit amet</span></td>', 20);
+		self::assertGreaterThan(256, strlen($filler));
+
+		self::assertNull(BounceDetector::matchBouncePattern($filler));
+
+		$matching = $filler . ' mailbox is full';
+		self::assertSame(self::naiveMatch($matching), BounceDetector::matchBouncePattern($matching));
+		self::assertSame('4.2.2', BounceDetector::matchBouncePattern($matching));
 	}
 
 	public function testLineWithoutAnyBounceTextIsNotMatched(): void {

--- a/tests/BounceDetectorTest.php
+++ b/tests/BounceDetectorTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zoon\BounceHandler\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Zoon\BounceHandler\Data\BouncePatterns;
+use Zoon\BounceHandler\Detector\BounceDetector;
+
+final class BounceDetectorTest extends TestCase {
+	/**
+	 * Образцы строк для паттернов, которые нельзя получить простым снятием экранирования.
+	 *
+	 * @var array<non-empty-string, non-empty-string>
+	 */
+	private const array PATTERN_SAMPLES = [
+		'[45]\d\d[- ]#?([45]\.\d\.\d{1,2})' => '550 5.1.1 user unknown',
+		'Diagnostic[- ][Cc]ode: smtp; ?\d\d\ ([45]\.\d\.\d{1,2})' => 'Diagnostic-Code: smtp; 55 4.4.7 timeout',
+		'Status: ([45]\.\d\.\d{1,2})' => 'Status: 4.7.1',
+		'over ?quota' => 'over quota',
+		'host ?name is unknown' => 'host name is unknown',
+		'blocke?d? for spam' => 'blocked for spam',
+	];
+
+	/**
+	 * Эталонная реализация: перебор всех паттернов по порядку, без предфильтра.
+	 */
+	private static function naiveMatch(string $line): ?string {
+		foreach (BouncePatterns::BOUNCE_LIST as $bouncetext => $bouncecode) {
+			if (preg_match("/{$bouncetext}/i", $line, $matches) === 1) {
+				if (array_key_exists(1, $matches) && $bouncecode === 'x') {
+					return $matches[1];
+				}
+
+				return $bouncecode;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @return iterable<string, array{non-empty-string, non-empty-string}>
+	 */
+	public static function bouncePatternProvider(): iterable {
+		foreach (array_keys(BouncePatterns::BOUNCE_LIST) as $pattern) {
+			$sample = self::PATTERN_SAMPLES[$pattern] ?? str_replace(['\.', '\/', '\ '], ['.', '/', ' '], $pattern);
+			self::assertNotSame('', $sample);
+
+			yield $pattern => [$pattern, $sample];
+		}
+	}
+
+	#[DataProvider('bouncePatternProvider')]
+	public function testPatternSampleIsMatchedTheSameWayAsNaiveScan(string $pattern, string $sample): void {
+		$expected = self::naiveMatch($sample);
+
+		self::assertNotNull($expected, "Образец строки для паттерна `{$pattern}` не распознаётся эталонным перебором");
+		self::assertSame($expected, BounceDetector::matchBouncePattern($sample));
+	}
+
+	public function testLineWithoutAnyBounceTextIsNotMatched(): void {
+		self::assertNull(BounceDetector::matchBouncePattern('Received: from mx.example.org by relay.example.net'));
+	}
+
+	public function testMatchesNaiveScanOnEveryFixtureLine(): void {
+		$mismatches = [];
+		foreach (self::fixtureLines() as $line) {
+			$expected = self::naiveMatch($line);
+			$actual = BounceDetector::matchBouncePattern($line);
+			if ($expected !== $actual) {
+				$mismatches[$line] = ['эталон' => $expected, 'получено' => $actual];
+			}
+		}
+
+		self::assertSame([], $mismatches);
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	private static function fixtureLines(): array {
+		$lines = [];
+		$files = glob(__DIR__ . '/../eml/*');
+		self::assertIsArray($files);
+		self::assertNotSame([], $files);
+
+		foreach ($files as $file) {
+			if (!is_file($file)) {
+				continue;
+			}
+
+			$content = file_get_contents($file);
+			self::assertIsString($content);
+
+			foreach (preg_split('/\r\n|\r|\n/', $content) ?: [] as $line) {
+				$line = trim($line);
+				if ($line !== '') {
+					$lines[$line] = true;
+				}
+			}
+		}
+
+		// Ключи массива, состоящие из цифр, PHP приводит к int — возвращаем строки явно.
+		return array_map(strval(...), array_keys($lines));
+	}
+}


### PR DESCRIPTION
## Проблема

`BounceDetector::getStatusCodeFromText()` прогоняет **каждую строку тела письма** через весь
словарь `BouncePatterns::BOUNCE_LIST` (~197 паттернов), по одному `preg_match` на паттерн.

На крупном bounce'е (вложенное исходное письмо с base64-частями, ~9000 строк) это 1,8 млн
вызовов `preg_match` и **161 мс на одно письмо**.

Компиляция регулярок тут не при чём: PCRE-кеш PHP хранит скомпилированные шаблоны, и
константный паттерн неотличим от переменной (29 нс на вызов в обоих случаях), а `pcre.jit=On`
компилирует их ещё и в машинный код. Дорого именно **число вызовов**: 197 × 29 нс ≈ 5,7 мкс
на строку только на оверхеде.

## Решение

Per-line поиск вынесен в `BounceDetector::matchBouncePattern()` и закрыт предфильтром —
одной альтернативой из всех паттернов `BOUNCE_LIST`, собираемой один раз на процесс
(`BouncePatterns::getCombinedBounceRegex()`).

Строка, не совпавшая с объединённым шаблоном, не может совпасть ни с одним паттерном
по отдельности, поэтому перебор пропускается целиком. Если объединённый шаблон совпал —
победителя по-прежнему определяет исходный цикл в порядке объявления, так что возвращаемый
статус-код не меняется. `preg_match` считается достоверным только при результате ровно `0`;
при ошибке PCRE (`false`) код проваливается в полный перебор, чтобы не потерять совпадение.

### Предфильтр включается не всегда

У двух стратегий противоположная форма стоимости. Перебор платит ~197 вызовов на строку,
но каждый — поиск литерала, который PCRE начинает с `memchr`, то есть почти бесплатен на
байт. Объединённая альтернатива — один вызов, но её start-bitmap покрывает почти все буквы,
поэтому на каждом смещении перебираются ~197 ветвей, и стоимость растёт с длиной строки.

| строка | перебор | предфильтр |
|---|---:|---:|
| заголовок, 62 Б | 17.6 мкс | **3.0 мкс** (6.0× ↑) |
| base64, 80 Б | 17.2 мкс | **4.3 мкс** (4.0× ↑) |
| HTML 1 КБ | **25.3 мкс** | 54.8 мкс (2.0× ↓) |
| HTML 11 КБ | **109.6 мкс** | 594.5 мкс (5.4× ↓) |
| HTML 110 КБ | **909.5 мкс** | 6025.5 мкс (6.6× ↓) |

При `pcre.jit=0` предфильтр проигрывает на любой длине (2.8×–7.2×).

Поэтому предфильтр включается только когда он действительно дешевле:

* **по длине строки** — точка безубыточности намерена около 350 Б, порог выставлен 256 Б.
  По корпусу `eml/` (37 868 строк) p50 = 37 Б, p99 = 104 Б, максимум 972 Б, длиннее 512 Б —
  8 строк (0.02 %). То есть быстрый путь сохраняется практически для всех реальных строк;
* **по доступности PCRE JIT** — `PCRE_JIT_SUPPORT` плюс `pcre.jit`.

Так снят сценарий, который ловится в проде: NDR от Exchange с невёрнутым 8bit HTML-оригиналом
даёт одиночные строки 10–50 КБ, а `getStatusCodeFromText()` проходит всё тело, включая
вложенный оригинал.

## Замеры

PHP 8.4 / PCRE 10.42, `getStatusCodeFromText()` по всему телу, фикстуры из `eml/`.
Статус-коды до и после — идентичные.

| Письмо | Строк | До | После | |
|---|---:|---:|---:|---:|
| `1.eml` | 704 | 0.064 ms | 0.018 ms | 3.6× |
| `fixture_bounce_001.eml` | 802 | 0.079 ms | 0.016 ms | 4.9× |
| `fixture_bounce_005.eml` | 851 | 0.229 ms | 0.040 ms | 5.7× |
| `fixture_bounce_008.eml` | 870 | 0.386 ms | 0.059 ms | 6.5× |
| `fixture_feedback_002.eml` | 8971 | 161.127 ms | 15.040 ms | **10.7×** |

Длинные строки и сборки без JIT после второго коммита совпадают с master в пределах шума.

## Тесты

`tests/BounceDetectorTest.php` — 233 теста. Ключевое: `matchBouncePattern()` обязан совпадать
с эталонным перебором `BOUNCE_LIST` по порядку — по образцу на каждый из 197 паттернов и по
всем 8329 уникальным строкам корпуса `eml/`.

Каждый тест проверен мутацией — что он действительно падает:

| Мутация | Результат |
|---|---|
| предфильтр стал неполным (150 паттернов из 197) | падает — паритет по корпусу |
| образец не совпадает со своим паттерном | падает |
| в `BOUNCE_LIST` добавлена обратная ссылка | падает |
| в `BOUNCE_LIST` две одноимённые группы | падает |
| приоритет заменён на leftmost вместо порядка списка | падает |
| `PCRE_JIT_SUPPORT === 1` вместо `=== true` | падает |

Последняя мутация — не гипотетическая: это живой баг из этой ветки. `PCRE_JIT_SUPPORT` —
`bool`, поэтому сравнение с `1` молча выключало предфильтр целиком, не меняя ни одного
результата. Поведенческие тесты такого не видят, поэтому решение проверяется напрямую.

**Чего тесты не покрывают:** сам гейт по длине строки — это чистая оптимизация без
наблюдаемого поведения, снятие порога не ломает ни один тест. Обоснование вынесено в
докблок константы вместе с замерами, timing-тест не добавлялся как флаки.

```
vendor/bin/phpunit   OK (233 tests, 1549 assertions)
vendor/bin/psalm     No errors found!
```

`phpcs` падает и на `master` (1878 нарушений, из них 1895 `DisallowTabIndent` — конфиг
требует пробелы, кодовая база на табах). Новый код на табах, как и всё вокруг; нарушений
других типов не добавлено (`ScopeIndent` 11, `ScopeClosingBrace` 2, `ControlStructureSpacing` 2 —
столько же, сколько на master).

## Что осталось за рамками

* **Премиса исходной задачи не подтверждается.** Тикет исходил из того, что 770 мс на письмо
  в `ProcessBounced` — это парсер. На типичном письме `parse()` укладывается в доли
  миллисекунды; по всему корпусу 0.238 → 0.184 мс на письмо. Патологический случай у парсера
  реальный и закрыт здесь, но 99 % времени почти наверняка уходит в IMAP FETCH —
  профилирование `ProcessBounced` со стороны потребителя всё равно нужно.
* **Trie-факторизация** объединённого шаблона (`[aA](?:ccount not found|…)`) даёт ещё 3× на
  предфильтре, но не спасает длинные строки (на 110 КБ всё равно ~2× медленнее перебора) и
  требует трёх нетривиальных запретов к содержимому паттернов, один из которых (top-level `|`)
  ломается молча. Не вошло.
* `matchBouncePattern()` сделан `public` — небольшое, но осознанное расширение публичного API
  библиотеки.
* `BounceHandler::processXFailedRecipients()` вызывает `getStatusCodeFromText()` по разу на
  каждый адрес с тем же телом, повторяя весь проход. Предсуществующее, не трогал.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AhbSiGDH1yYXJ5u7XPdzf
