### PR TITLE
fix: не терять reason filtered у не-FBL писем со статусом 5.7.1

### DIFF
--- a/src/BounceHandler.php
+++ b/src/BounceHandler.php
@@ -8,7 +8,6 @@ use Zoon\BounceHandler\Detector\AutoResponseDetector;
 use Zoon\BounceHandler\Detector\BounceDetector;
 use Zoon\BounceHandler\Detector\FblDetector;
 use Zoon\BounceHandler\Enum\BounceAction;
-use Zoon\BounceHandler\Enum\BounceReason;
 use Zoon\BounceHandler\Enum\EmailType;
 use Zoon\BounceHandler\Extractor\EmailAddressExtractor;
 use Zoon\BounceHandler\Parser\DsnParser;
@@ -176,12 +175,6 @@ final class BounceHandler {
 			}
 
 			$reason = StatusCodeResolver::getReason($deliveryStatus);
-			if (
-				$reason === BounceReason::Filtered
-				&& $emailType !== EmailType::Fbl
-			) {
-				$reason = BounceReason::UserUnknown;
-			}
 
 			$results[] = new BounceResult(
 				emailType: $emailType ?? EmailType::Bounce,

--- a/tests/BounceHandlerTest.php
+++ b/tests/BounceHandlerTest.php
@@ -63,7 +63,7 @@ final class BounceHandlerTest extends TestCase {
 		self::assertSame(BounceReason::UserUnknown, $results[0]->reason);
 	}
 
-	public function testParsesMailDeliveryFailedFixtureAsUserUnknownBounce(): void {
+	public function testParsesMailDeliveryFailedFixtureAsFilteredBounce(): void {
 		$handler = new BounceHandler();
 		$results = $handler->parse($this->readFixture('fixture_bounce_001.eml'));
 
@@ -72,7 +72,19 @@ final class BounceHandlerTest extends TestCase {
 		self::assertSame(BounceAction::Failed, $results[0]->action);
 		self::assertSame('5.7.1', $results[0]->deliveryStatus);
 		self::assertSame('recipient.one@example.test', $results[0]->recipient);
-		self::assertSame(BounceReason::UserUnknown, $results[0]->reason);
+		self::assertSame(BounceReason::Filtered, $results[0]->reason);
+	}
+
+	public function testKeepsFilteredReasonForNonFblBounceWithStatus571(): void {
+		$handler = new BounceHandler();
+		$results = $handler->parse($this->readFixture('32.eml'));
+
+		self::assertCount(1, $results);
+		self::assertSame(EmailType::Bounce, $results[0]->emailType);
+		self::assertSame(BounceAction::Failed, $results[0]->action);
+		self::assertSame('5.7.1', $results[0]->deliveryStatus);
+		self::assertSame('stellamiranda@interlink.com.ar', $results[0]->recipient);
+		self::assertSame(BounceReason::Filtered, $results[0]->reason);
 	}
 
 	public function testDetectsAutoResponseFromHeaders(): void {


### PR DESCRIPTION
## Проблема

Многие MTA отдают 5.7.1 на несуществующий адрес. Ровно такой кейс лежит в фикстуре eml/fixture_bounce_001.eml:38:               
550 5.7.1 No such user!                                                     

поэтому был добавлен код:
```php
$reason = StatusCodeResolver::getReason($deliveryStatus);
if (
    $reason === BounceReason::Filtered
    && $emailType !== EmailType::Fbl
) {
    $reason = BounceReason::UserUnknown;
}
```

Я хочу убрать, потому что мы таким образом теряем реальные причины bounce. А юзера можем отписать после получения n таких писем, а не сразу.
На нашей выборке из 2 206 записей
со статусом `5.7.1` под `userunknown` оказались отказы вида
`Message rejected under suspicion of SPAM`, `Your IP address is listed by Spamhaus Zen`,
`TRANSPORT.RULES.RejectMessage` — и лишь 2 записи с настоящим `No such user`.

## Что теряем. 
Адрес, который действительно умер, но раньше получал письма, отпишется не с первого-второго баунса, а с третьего-четвёртого — по порогу log10

## Как было в 7.x

Формально `get_reason_by_statuscode()` возвращал `filtered` для `5.7.1` без оглядки на тип
письма. Фактически не-FBL письма с этим статусом до классификации не доходили: прогон
7.x-драйвера по всем 90 фикстурам `eml/` даёт `filtered` ровно у трёх файлов, и все три —
FBL (`arf1.txt`, `arf2.txt`, `arf3.txt`). `eml/32.eml` с честным DSN `Status: 5.7.1` старый
парсер признавал баунсом, но возвращал ноль строк, а `fixture_bounce_001.eml` не признавал
баунсом вообще (26 из 90 писем он не разбирал).

Тот же прогон на 8.0 даёт два не-FBL письма с `5.7.1` — `32.eml` и `fixture_bounce_001.eml`.
То есть 8.0 научился разбирать класс писем, который 7.x пропускал, и вместе с ним впервые
появился не-FBL `filtered`. Условие сохраняло прежнее фактическое поведение «filtered бывает
только у FBL» — но способом, который стирает признак фильтрации вместе с реальными случаями.

Показательно, что эти два новых письма делятся ровно пополам: в `fixture_bounce_001.eml`
за `5.7.1` стоит `No such user!`, в `32.eml` — `Message content rejected, UBE`. Правило
«не-FBL `5.7.1` = userunknown» верно для первого и ложно для второго, и по статусу их
не различить — только по тексту `Diagnostic-Code`, которого у большинства таких писем нет.

## Решение

Принудительный перевод убран — `getReason()` остаётся единственным источником причины.
Оговорка про FBL больше не нужна: FBL-ветка сама проставляет жалобам `5.7.1`, и `filtered`
для них по-прежнему верен.

## Тесты

* `testKeepsFilteredReasonForNonFblBounceWithStatus571` — новый, на существующей фикстуре
  `eml/32.eml` с честным DSN `Status: 5.7.1` и `Diagnostic-Code: 550 5.7.1 Message content
  rejected, UBE`. На `master` падает (`filtered` приходил как `userunknown`).
* `testParsesMailDeliveryFailedFixtureAsUserUnknownBounce` → переименован
  в `...AsFilteredBounce` и ожидает `Filtered`. Фикстура `fixture_bounce_001.eml` —
  это `550 5.7.1 No such user!`, то есть тот редкий случай, когда за `5.7.1` действительно
  стоит несуществующий адрес. Такие письма теперь классифицируются как `filtered`;
  различать их можно только по тексту `Diagnostic-Code`, и это ответственность потребителя,
  а не разбора статуса.

```
vendor/bin/phpunit   OK (30 tests, 859 assertions)
vendor/bin/psalm     No errors found!
```

`phpcs` падает и на `master` (1878 нарушений `Generic.WhiteSpace.DisallowTabIndent` — конфиг
требует пробелы, кодовая база на табах); правка их число не увеличивает.

## Что учесть потребителю

После обновления часть писем сменит `reason` с `userunknown` на `filtered`. Если обработчик
отписывает по `userunknown`, эти получатели перестанут отписываться по единичному отказу —
что и есть цель правки, — но ветку под `filtered` в нём нужно иметь.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SDwSk8cKZbCSWxbDnCThL
